### PR TITLE
Add bills to import rake

### DIFF
--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -1,5 +1,5 @@
 class Bill < ApplicationRecord
-  has_many :positions
+  has_many :positions, dependent: :destroy
   has_many :clients, through: :positions
   has_many :lobbyists, through: :positions
 end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,7 +1,7 @@
 class Client < ApplicationRecord
   belongs_to :lobbyist
   has_many :incomes, dependent: :destroy
-  has_many :positions
+  has_many :positions, dependent: :destroy
   has_many :bills, through: :positions
 
   def total_income

--- a/lib/tasks/import_lobbyists.rake
+++ b/lib/tasks/import_lobbyists.rake
@@ -185,7 +185,7 @@ namespace :import_data do
   end
 
   desc "import all lobbying data"
-  task all: [:lobbyists, :clients, :incomes] do
+  task all: [:lobbyists, :clients, :incomes, :bill_positions] do
     puts "","ALL LOBBYING DATA IMPORTED"
   end
 end


### PR DESCRIPTION
This PR
- Fixes the initial import rake task `rails import_data:all` to now import bill positions and data
- This updates the bill and client models to destroy positions when a lobbyist and client are erased